### PR TITLE
Fixes and tests for single-dimension arrays + less allocations in WriteString

### DIFF
--- a/Ceras.Test/ArrayTest.cs
+++ b/Ceras.Test/ArrayTest.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Ceras.Test
+{    
+    public class ArrayTest
+    {
+        CerasSerializer _s = new CerasSerializer();
+
+        private T Roundtrip<T>(T value)
+        {
+            return _s.Deserialize<T>(_s.Serialize(value));
+        }
+
+        [Fact]
+        public void ByteArrayRtt()
+        {            
+            var nullBytes = Roundtrip((byte[])null);
+            Assert.Equal((byte[])null, nullBytes);
+            
+            var zeroBytes = Roundtrip(Array.Empty<byte>());
+            Assert.Equal(zeroBytes, Array.Empty<byte>());
+
+            var r = new Random(DateTime.Now.GetHashCode());
+            var bytesData = new byte[r.Next(100, 200)];
+            r.NextBytes(bytesData);
+           
+            var singleBytes = Roundtrip(bytesData);
+            Assert.Equal(bytesData, singleBytes);
+        }
+
+        [Fact]
+        public void StructArrayRtt()
+        {
+            var nullBytes = Roundtrip((decimal[])null);
+            Assert.Equal((decimal[])null, nullBytes);
+
+            var zeroBytes = Roundtrip(Array.Empty<decimal>());
+            Assert.Equal(zeroBytes, Array.Empty<decimal>());
+
+            var r = new Random(DateTime.Now.GetHashCode());
+            var decimalData = new decimal[r.Next(100, 200)];
+            for(var i = 0; i < decimalData.Length; ++i)
+                decimalData[i] = (decimal)r.NextDouble();
+
+            var singleBytes = Roundtrip(decimalData);
+            Assert.Equal(decimalData, singleBytes);
+        }
+    }
+}

--- a/Ceras.Test/Ceras.Test.csproj
+++ b/Ceras.Test/Ceras.Test.csproj
@@ -61,6 +61,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArrayTest.cs" />
     <Compile Include="UnitTest1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Ceras.Test/UnitTest1.cs
+++ b/Ceras.Test/UnitTest1.cs
@@ -17,7 +17,7 @@ namespace Ceras.Test
 			Assert.Equal(1, data.Length);
 
 			data = _s.Serialize<string>(null);
-			Assert.Equal(new byte[1] { 0 }, data);
+			Assert.Equal(new byte[1] { 3 }, data);
 
 			data = _s.Serialize(0);
 			Assert.Equal(new byte[1] { 0 }, data);
@@ -49,7 +49,7 @@ namespace Ceras.Test
 
 
 			data = _s.Serialize("12345");
-			Assert.Equal(6, data.Length); // 1byte length, 5bytes content
+		    Assert.Equal(new byte[] {1, 6, 49, 50, 51, 52, 53}, data);// 1byte length, 5bytes content
 		}
 
 		[Fact]

--- a/Ceras/Ceras.csproj
+++ b/Ceras/Ceras.csproj
@@ -34,12 +34,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Exceptions\CerasException.cs" />

--- a/Ceras/Formatters/ReferenceFormatter.cs
+++ b/Ceras/Formatters/ReferenceFormatter.cs
@@ -213,7 +213,7 @@
 			// todo: enforce all types to have a parameterless constructor
 			bool isRefType = !specificType.IsValueType;
 			bool isStringOrType = typeof(T) == typeof(string) || typeof(T) == typeof(Type);
-			
+
 
 			if (value == null)
 			{
@@ -267,9 +267,9 @@
 			T value;
 			var factory = _serializer.Config.ObjectFactoryMethod;
 			if (factory != null)
-				value = (T) _serializer.Config.ObjectFactoryMethod(specificType);
+				value = (T)_serializer.Config.ObjectFactoryMethod(specificType);
 			else
-				value = (T) GetConstructor(specificType)();
+				value = (T)GetConstructor(specificType)();
 			return value;
 		}
 
@@ -414,21 +414,23 @@
 			if (_objectConstructors.TryGetValue(type, out var f))
 				return f;
 
-		    if(type.IsArray)
-		    {//ArrayFormatter will create a new array
-                f = (() => null);
-		    } else
-		    {
-		        var ctor = type.GetConstructors(BindingFlags.Public|BindingFlags.Instance)
-		            .FirstOrDefault(c => c.GetParameters().Length == 0);
+			if (type.IsArray)
+			{
+				// ArrayFormatter will create a new array
+				f = () => null;
+			}
+			else
+			{
+				var ctor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+					.FirstOrDefault(c => c.GetParameters().Length == 0);
 
-		        if(ctor == null)
-		            throw new Exception($"Cannot deserialize type '{type.FullName}' because it has no parameterless constructor (support for serialization-constructors will be added in the future)");
+				if (ctor == null)
+					throw new Exception($"Cannot deserialize type '{type.FullName}' because it has no parameterless constructor (support for serialization-constructors will be added in the future)");
 
-		        f = (Func<object>)CreateConstructorDelegate(ctor, typeof(Func<object>));
-		    }
+				f = (Func<object>)CreateConstructorDelegate(ctor, typeof(Func<object>));
+			}
 
-		    _objectConstructors[type] = f;
+			_objectConstructors[type] = f;
 			return f;
 		}
 

--- a/Ceras/Formatters/ReferenceFormatter.cs
+++ b/Ceras/Formatters/ReferenceFormatter.cs
@@ -414,14 +414,21 @@
 			if (_objectConstructors.TryGetValue(type, out var f))
 				return f;
 
-			var ctor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
-						   .FirstOrDefault(c => c.GetParameters().Length == 0);
+		    if(type.IsArray)
+		    {//ArrayFormatter will create a new array
+                f = (() => null);
+		    } else
+		    {
+		        var ctor = type.GetConstructors(BindingFlags.Public|BindingFlags.Instance)
+		            .FirstOrDefault(c => c.GetParameters().Length == 0);
 
-			if (ctor == null)
-				throw new Exception($"Cannot deserialize type '{type.FullName}' because it has no parameterless constructor (support for serialization-constructors will be added in the future)");
+		        if(ctor == null)
+		            throw new Exception($"Cannot deserialize type '{type.FullName}' because it has no parameterless constructor (support for serialization-constructors will be added in the future)");
 
-			f = (Func<object>)CreateConstructorDelegate(ctor, typeof(Func<object>));
-			_objectConstructors[type] = f;
+		        f = (Func<object>)CreateConstructorDelegate(ctor, typeof(Func<object>));
+		    }
+
+		    _objectConstructors[type] = f;
 			return f;
 		}
 

--- a/Ceras/SerializerBinary.cs
+++ b/Ceras/SerializerBinary.cs
@@ -381,7 +381,7 @@
 	        // If Encoding.UTF8 will be replaced in future - original implementation
 	        // might be even faster.
             var valueBytesCount = Encoding.UTF8.GetByteCount(value);
-	        EnsureCapacity(ref buffer, offset, valueBytesCount + 5);// 5 bytes space for the varint
+	        EnsureCapacity(ref buffer, offset, valueBytesCount + 5); // 5 bytes space for the varint
 
 	        // Length
 	        WriteUInt32Bias(ref buffer, ref offset, valueBytesCount, 1);


### PR DESCRIPTION
Fixed bug with arrays (missing .ctor), added unit-test for single-dimension arrays. Removed byte[] allocation in SerializerBinary.WriteString()
