### PR TITLE
Readonly field handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ var bytes = s.Serialize(p);
 - Can serialize Fields and Properties (Check out the [**Tutorial**](https://github.com/rikimaru0345/Ceras/blob/master/LiveTesting/Tutorial.cs) to see all the different configuration options)
   - `ShouldSerialize` Callback > Member-Attribute > Class-Attribute > Global Default
 - No need to place attributes on members
-  - Serialization is still completely "stable", since members are sorted by MemberTypeName+MemberName
+  - Serialization is completely "stable", since members are sorted by more than just field-name, type-name, ...
 - Efficient:
   - By default no versioning-, type- or other meta-data is written, only what is strictly needed.
   - Utilizes both VarInt & Zig-Zag encoding (example: values up to 128 only take 1 byte instead of 4...)
@@ -60,9 +60,14 @@ var bytes = s.Serialize(p);
 - Very easy to add new "Formatters" (the things that the serializer uses to actually read/write an object)
 - Various Attributes like `[Config]`, `[Ignore]`, `[Include]`
 - Version tolerance. Supports all changes: adding new / renaming / reordering / deleting members.
+- Ceras can handle `readonly` fields in various ways. Ceras can change the contents of objects in readonly fields without having to change the reference in the field itself (aka 'populate' with data). Or it can force-overwrite readonly fields if you really want to (using reflection).
+- Good exceptions: All exceptions Ceras throws contain reasons why something went wrong and what to do about it.  
 
 #### Built-in types
-Built-in support for many commonly used .NET types: Primitives(`int`, `string`, ...), `Enum`, `decimal`, `DateTime`, `TimeSpan`, `DateTimeOffset`, `Guid`, `Array[]`, `KeyValuePair<,>`, `Nullable<>`, everything that implements `ICollection<>` so `List<>`, `Dictionary<,>`, ... 
+Built-in support for many commonly used .NET types:
+- Primitives(`int`, `string`, ...), `Enum`
+- All `ICollection<>` so `List<>`, `Dictionary<,>`, ... 
+- Pretty much all commonly used BCL types: `decimal`, `DateTime`, `TimeSpan`, `DateTimeOffset`, `Guid`, `Array[]`, `KeyValuePair<,>`, `Nullable<>`, `BitVector32`,
 
 Automatically generates optimized formatters for your types! No attributes or anything needed, everything fully automatic.
 
@@ -121,7 +126,6 @@ Report it as an issue. If it's a common type I'll most likely add a dedicated bu
 
 
 # Planned features
-- .NET standard build target
 - "Serialization Constructors" for immutable collections (also supporting private static methods for construction)
 - Performance comparisons beyond simple micro benchmarks
 - Better exceptions (actual exception types instead of the generic `Exception`)
@@ -132,6 +136,7 @@ Report it as an issue. If it's a common type I'll most likely add a dedicated bu
 - Built-in LZ4 and GZip(Zlib) support, including support for Sync-Flush (especially useful for networking scenarios)
 
 ### Done
+- .NET standard build target
 - Making Ceras available as a nuget package
 - Automatic release builds
 - Automatic version tolerance can now be enabled through config. `config.VersionTolerance = VersionTolerance.AutomaticEmbedded;`. More options will follow in the future including manual version tolerance if you want to go the extra mile to optimize your code. 

--- a/samples/LiveTesting/Program.cs
+++ b/samples/LiveTesting/Program.cs
@@ -17,6 +17,8 @@ namespace LiveTesting
 
 		static void Main(string[] args)
 		{
+			ReadonlyTest();
+
 			DelegatesTest();
 
 			SimpleDictionaryTest();
@@ -71,6 +73,58 @@ namespace LiveTesting
 
 		}
 
+		private static void ReadonlyTest()
+		{
+			SerializerConfig config = new SerializerConfig();
+			config.ReadonlyFieldHandling = ReadonlyFieldHandling.Off;
+			CerasSerializer s = new CerasSerializer(config);
+
+			ReadonlyTestClass test = new ReadonlyTestClass(9999);
+			test.Settings.Setting1 = 2222;
+			test.Settings.Setting2 = "asdasdasda";
+
+
+			var clone1 = s.Deserialize<ReadonlyTestClass>(s.Serialize(test));
+
+			// Feature is off, expect that fields are ignored:
+			Assert.Equal(5, clone1.Number);
+			Assert.Equal(1, clone1.Settings.Setting1);
+			Assert.Equal("a", clone1.Settings.Setting2);
+
+
+
+			config.ReadonlyFieldHandling = ReadonlyFieldHandling.Members;
+
+			// todo: test mismatch throws exception
+			// todo: test readonly number is not fixed
+			// todo: test settings are correctly restored
+
+		}
+
+		class ReadonlyTestClass
+		{
+			public readonly int Number = 5;
+
+			public readonly MySettings Settings = new MySettings();
+
+			public class MySettings
+			{
+				public int Setting1 = 1;
+				public string Setting2 = "a";
+			}
+
+
+			public ReadonlyTestClass()
+			{
+			}
+
+			public ReadonlyTestClass(int number)
+			{
+				Number = number;
+			}
+		}
+
+
 		static int Add1(int x) => x + 1;
 		static int Add2(int x) => x + 2;
 
@@ -106,7 +160,7 @@ namespace LiveTesting
 			multipleTypesHolder.Type1 = typeof(Person);
 			multipleTypesHolder.Type2 = typeof(Person);
 			multipleTypesHolder.Type3 = typeof(Person);
-			
+
 			multipleTypesHolder.Object1 = new Person();
 			multipleTypesHolder.Object2 = new Person();
 			multipleTypesHolder.Object3 = multipleTypesHolder.Object1;

--- a/samples/LiveTesting/Program.cs
+++ b/samples/LiveTesting/Program.cs
@@ -17,6 +17,8 @@ namespace LiveTesting
 
 		static void Main(string[] args)
 		{
+			VersionToleranceTest();
+
 			ReadonlyTest();
 
 			DelegatesTest();
@@ -32,8 +34,6 @@ namespace LiveTesting
 			InheritTest();
 
 			StructTest();
-
-			VersionToleranceTest();
 
 			WrongRefTypeTest();
 
@@ -681,7 +681,7 @@ namespace LiveTesting
 			var obj = new ConstructorTest(5);
 			var ceras = new CerasSerializer();
 			var data = ceras.Serialize(obj);
-
+			
 			// This is expected to throw an exception
 			try
 			{

--- a/samples/LiveTesting/Tutorial.cs
+++ b/samples/LiveTesting/Tutorial.cs
@@ -8,6 +8,7 @@ namespace Tutorial
 	using Newtonsoft.Json.Linq;
 	using System;
 	using System.Collections.Generic;
+	using System.Diagnostics;
 
 	class Person
 	{
@@ -517,7 +518,7 @@ namespace Tutorial
 
 			var newData = serializer.Serialize(newSettings);
 		}
-	
+
 		public void Step9_VersionTolerance()
 		{
 			/*
@@ -561,7 +562,13 @@ namespace Tutorial
 			 */
 
 
-			// todo: example
+			{
+				
+				
+			}
+
+
+
 
 			// todo: explain that its only for readonly fields. 
 			// Readonly props can add a {private set;}, 
@@ -571,6 +578,8 @@ namespace Tutorial
 			// todo: explain in detail what a mismatch is (null -> not null,  not null -> null, polymorphic type mismatch)
 		}
 	}
+
+
 
 	static class MyGameDatabase
 	{

--- a/samples/LiveTesting/Tutorial.cs
+++ b/samples/LiveTesting/Tutorial.cs
@@ -470,7 +470,7 @@ namespace Tutorial
 
 		}
 
-		public void Step8_DataUpgrade()
+		public void Step8_DataUpgrade_OLD()
 		{
 			/*
 			 * So you have a settings class or something, and now you have done 3 types of changes:
@@ -516,6 +516,59 @@ namespace Tutorial
 			var newSettings = jObj.ToObject<SettingsNew>();
 
 			var newData = serializer.Serialize(newSettings);
+		}
+	
+		public void Step9_VersionTolerance()
+		{
+			/*
+			 * This is like V2 of the 'DataUpgrade' section.
+			 * Since then Ceras got a VersionTolerance feature which can be enabled in the config.
+			 * 
+			 * 
+			 */
+
+			// todo 1: show how to use it
+
+			// todo 2: mention that any type-changes of existing fields are not supported (int X; becoming a float X; or so)
+
+			// todo 3: show how to deal with changing types (like in #8, just keep the old object around) 
+
+			// todo 4: In the future: Embed type-data and maybe a version number, so Ceras can also deal with changing types!
+			//         Advantage: Now we have perfect version tolerance, no need for any workarounds!
+			//		   Disadvantage: Uses more additional space, we can't magically save more data (the member types) without using more space.
+			//		   Problems: If we are asked to load an older type, and we see that a type has changed, we need the user to provide some sort of type-converter thingy.
+			//				     but we can probably do automatic conversion for all the simple stuff (int->float, ...), but maybe that's too dangerous.
+			//				     What if someone has a locale set that uses '.' and we use ',' and then "1.45" becomes 145 as int (which is ofc wrong)
+		}
+
+		public void Step10_ReadonlyHandling()
+		{
+			/*
+			 * Situation:
+			 * 
+			 * You have an object, which has a 'readonly Settings CurrentSettings;'.
+			 * Of course that can't (normally) be serialized or deserialized.
+			 * But Ceras can still deal with it.
+			 * 
+			 * Default: readonly fields are completely ignored
+			 * 
+			 * Members: save/restore the content of the variable itself
+			 * 
+			 * Forced: also fix if there's a mismatch
+			 * 
+			 * 
+			 * 
+			 */
+
+
+			// todo: example
+
+			// todo: explain that its only for readonly fields. 
+			// Readonly props can add a {private set;}, 
+			// and if for whatever reason simply adding a private set is not possible and you only have a {get;}=...; then things get extremely complicated 
+			// with SkipCompilerGeneratedFields and all the tons of problems that comes with.
+
+			// todo: explain in detail what a mismatch is (null -> not null,  not null -> null, polymorphic type mismatch)
 		}
 	}
 

--- a/src/Ceras/Ceras.csproj
+++ b/src/Ceras/Ceras.csproj
@@ -2,7 +2,7 @@
   <!-- Global metadata -->
   <PropertyGroup>
     <Version>2.0.0</Version>
-    <Authors>riki</Authors>
+    <Authors>rikimaru0345 (GitHub); Bloodskilled/Rikimaru#0345 (Discord)</Authors>
     <Copyright>https://github.com/rikimaru0345/Ceras/blob/master/LICENSE</Copyright>
     <PackageProjectUrl>https://github.com/rikimaru0345/Ceras</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rikimaru0345/Ceras</RepositoryUrl>
@@ -13,13 +13,14 @@ zero allocations and pooling to avoid GC pressure,
 ability to serialize an object graph into multiple "fragments" (aka external objects), ...
 and much more checkout the github page for a full list!
 </Description>
-    <PackageTags>utility, ceras, serialization, serializer, formatter, unity, unity3d, network, networking</PackageTags>
+    <PackageTags>utility, ceras, serialization, binary, serializer, formatter, unity, unity3d, network, networking</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0;</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>7.1</LangVersion>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Ceras/Formatters/ConstructorFormatter.cs
+++ b/src/Ceras/Formatters/ConstructorFormatter.cs
@@ -1,0 +1,43 @@
+﻿namespace Ceras.Formatters
+{
+
+	/*
+	 * Situation:
+	 * There's an object that has no parameterless constructor. Either it always needs parameters, or there's a static 'Create' method.
+	 * 
+	 * Problem:
+	 * Currently we instantiate a new object and then we populate the members.
+	 * 
+	 * Approach:
+	 * Read all values into local variables,
+	 * then construct the object using whatever method there is (serialization ctor or static factory method).
+	 * Once we have the object we simply assign the remaining members.
+	 * 
+	 * Things to keep in mind:
+	 * - Ensure all remaining members can be written
+	 * - Ensure we read all members into locals for two reasons:
+	 *		- most likely the order of the members will not exactly match the constructor
+	 *		- performance is better with multiple consecutive read steps, then all assignment steps
+	 *		- code is much simpler
+	 * 
+	 * 
+	 * !! Big problem:
+	 * What if the object in question has a sub-object, which contains a reference to the parent?
+	 * At that point we do not have that object yet since we're still "collecting" the individual members...
+	 * Pre-creating a deserialization proxy like we already do won't help! The proxy must have a value at the time the sub-object is created (which is of course not the case then)
+	 * 
+	 * It seems like a pretty hard problem.
+	 * - Maybe I can think of something when I have more time, or someone else comes up with an idea
+	 * - Maybe we can cheat? Like we'd leave the reference be null, and then have some sort of 'post deserialization' callback or something where the user can fix whatever mess was created?
+	 *   DeserializationCallbacks are on the todo list anyway!
+	 * - Maybe treat it as an explicitly not-supported edge case?
+	 * 
+	 *
+	 */
+
+	// Not sure if the name really fits, maybe an alternative would be DelayedFormatter or something...
+
+	class ConstructorFormatter
+	{
+	}
+}

--- a/src/Ceras/Formatters/DynamicObjectFormatter.cs
+++ b/src/Ceras/Formatters/DynamicObjectFormatter.cs
@@ -30,7 +30,7 @@ namespace Ceras.Formatters
 			BannedTypes.ThrowIfBanned(type);
 			BannedTypes.ThrowIfNonspecific(type);
 
-			var schema = serializer.GetSerializationSchema(type, _ceras.Config.DefaultTargets, _ceras.Config.SkipCompilerGeneratedFields, _ceras.Config.ShouldSerializeMember);
+			var schema = CerasSerializer.GetSerializationSchema(type, _ceras.Config);
 
 			if (schema.Members.Count > 0)
 			{

--- a/src/Ceras/Formatters/DynamicObjectFormatter.cs
+++ b/src/Ceras/Formatters/DynamicObjectFormatter.cs
@@ -15,7 +15,7 @@ namespace Ceras.Formatters
 
 
 	// todo: Can we use a static-generic as a cache instead of dict? Is that even possible in our case? Would we even save anything? How much would it be faster?
-	public class DynamicObjectFormatter<T> : IFormatter<T>
+	class DynamicObjectFormatter<T> : IFormatter<T>
 	{
 		CerasSerializer _ceras;
 		SerializeDelegate<T> _dynamicSerializer;
@@ -30,7 +30,7 @@ namespace Ceras.Formatters
 			BannedTypes.ThrowIfBanned(type);
 			BannedTypes.ThrowIfNonspecific(type);
 
-			var schema = CerasSerializer.GetSerializationSchema(type, _ceras.Config);
+			var schema = _ceras.SchemaDb.GetOrCreatePrimarySchema(type);
 
 			if (schema.Members.Count > 0)
 			{

--- a/src/Ceras/Formatters/DynamicObjectFormatter.cs
+++ b/src/Ceras/Formatters/DynamicObjectFormatter.cs
@@ -183,11 +183,12 @@ namespace Ceras.Formatters
 							else
 								onReassignment = Expression.Throw(Expression.Constant(new Exception("The reference in the readonly-field '"+fieldInfo.Name+"' would have to be overwritten, but forced overwriting is not enabled in the serializer settings. Either make the field writeable or enable ForcedOverwrite in the ReadonlyFieldHandling-setting.")));
 
-							// 1. Did the reference change?
+							// Did the reference change?
 							block.Add(Expression.IfThenElse(
 								test: Expression.ReferenceEqual(tempStore, Expression.MakeMemberAccess(refValueArg, member.MemberInfo)),
 								
-								// Still the same. Whatever happened (null, seen object, external object, type), it seems to be ok.
+								// Still the same. Whatever has happened (and there are a LOT of cases), it seems to be ok.
+								// Maybe the existing object's content was overwritten, or the instance reference was already as expected, or...
 								ifTrue: Expression.Empty(),
 
 								// Reference changed. Handle it depending on if its allowed or not

--- a/src/Ceras/Formatters/TypeFormatter.cs
+++ b/src/Ceras/Formatters/TypeFormatter.cs
@@ -100,18 +100,35 @@
 				typeCache.RegisterObject(type);
 			}
 
-
 			if (_serializer.Config.VersionTolerance == VersionTolerance.AutomaticEmbedded)
 				if (!CerasSerializer.FrameworkAssemblies.Contains(type.Assembly))
 				{
 					// Get Schema
 					var schema = _serializer.SchemaDb.GetOrCreatePrimarySchema(type);
 
-					// Write it
-					_serializer.SchemaDb.WriteSchema(ref buffer, ref offset, schema);
+					// Write it (if not done yet)
+
+					if(!_serializer.InstanceData.WrittenSchemata.Contains(schema))
+					{
+						_serializer.InstanceData.WrittenSchemataList.Add(schema); // need to enter into the list as well so we know in what order the schemata are used
+						_serializer.SchemaDb.WriteSchema(ref buffer, ref offset, schema);
+					}
 
 					// Make the formatter available, if we're called from TypeFormatter then this will be the next thing
 					_serializer.ActivateSchemaOverride(type, schema);
+
+
+					// todo: collect all schemata, embed them in front, add hash and skip-over thing, ...
+					// todo: while reading the schema block, all specific serializers have to be created first before any reference formatters are allowed to be created.
+					// todo: how? how is this solved right now? If a DynamicFormatter has a field reference to itself, how does that work
+					//			- For ValueTypes: they cannot contain fields as themselves in anyway (would be infinite recursion)
+					//			- ReferenceTypes: when a DynamicFormatter<T> is created, and T has a field of type T inside it as well, it obtains a ReferenceFormatter<T> instead.
+					//							  that way the actual specific formatter is resolved later (when the first DynamicFormatter<T> has completed its construction)
+					// Even when constructing a dynamicFormatter and it contains a reference to some object, it will always ask for a referenceFormatter first.
+					// Problem: If an object contains a custom value-type it will not use the reference formatter.
+					// Solution:
+					// -> We must always construct formatters for value-types first.
+					throw new Exception("version tolerance is currently being reworked");
 				}
 		}
 

--- a/src/Ceras/Helpers/FastExpressionCompiler.cs
+++ b/src/Ceras/Helpers/FastExpressionCompiler.cs
@@ -24,6 +24,8 @@ THE SOFTWARE.
 
 // ReSharper disable CoVariantArrayConversion
 
+#if FAST_EXP
+
 #if LIGHT_EXPRESSION
 namespace FastExpressionCompiler.LightExpression
 #else
@@ -3593,3 +3595,7 @@ namespace FastExpressionCompiler
         }
     }
 }
+
+
+
+#endif

--- a/src/Ceras/SerializerBinary.cs
+++ b/src/Ceras/SerializerBinary.cs
@@ -428,19 +428,19 @@
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void EnsureCapacity(ref byte[] buffer, int offset, int size)
 		{
-			int newSize = offset + size;
-
 			if (buffer == null)
 			{
-				buffer = new byte[0x4000];
+				buffer = new byte[0x4000]; // 16k
 				return;
 			}
+
+			int newSize = offset + size;
 
 			if (buffer.Length >= newSize)
 				return;
 
-			if (newSize < 0x1000)
-				newSize = 0x1000;
+			if (newSize < 0x4000)
+				newSize = 0x4000;
 			else
 				newSize *= 2;
 

--- a/src/Ceras/SerializerBinary.cs
+++ b/src/Ceras/SerializerBinary.cs
@@ -179,6 +179,33 @@
 
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static void WriteUInt32Fixed(ref byte[] buffer, ref int offset, uint value)
+		{
+			EnsureCapacity(ref buffer, offset, 4);
+
+			fixed (byte* pBuffer = buffer)
+			{
+				*((uint*)(pBuffer + offset)) = value;
+			}
+
+			offset += 4;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static uint ReadUInt32Fixed(byte[] buffer, ref int offset)
+		{
+			uint value;
+
+			fixed (byte* pBuffer = buffer)
+			{
+				value = *((uint*)(pBuffer + offset));
+			}
+
+			offset += 4;
+			return value;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static void WriteByte(ref byte[] buffer, ref int offset, byte value)
 		{
 			EnsureCapacity(ref buffer, offset, 1);

--- a/src/Ceras/Versioning/Schema.cs
+++ b/src/Ceras/Versioning/Schema.cs
@@ -318,7 +318,8 @@
 				else
 					continue;
 
-				var serializedMember = SerializedMember.Create(m);
+				bool allowReadonly = _config.ReadonlyFieldHandling != ReadonlyFieldHandling.Off;
+				var serializedMember = SerializedMember.Create(m, allowReadonly);
 
 				// should we allow users to provide a formatter for each old-name (in case newer versions have changed the type of the element?)
 				var attrib = m.GetCustomAttribute<PreviousNameAttribute>();

--- a/src/Ceras/Versioning/Schema.cs
+++ b/src/Ceras/Versioning/Schema.cs
@@ -1,30 +1,54 @@
 ﻿namespace Ceras.Helpers
 {
-	using Formatters;
 	using System;
 	using System.Collections.Generic;
 	using System.Linq;
 	using System.Reflection;
+	using System.Runtime.CompilerServices;
+	using Ceras.Formatters;
 
 	/*
-	* A schema is super simple.
-	* It's just the members of an object (with an emphasis that the order in which they appear is important as well)
-	* Optionally the user can provide a custom formatter.
-	*
-	* At serialization time:
-	* - Write schema to buffer
-	* - Write objects using schema formatter (which will prefix every written member with its size)
-	*
-	* At deserialization time:
-	* - Read schema from file
-	*    - Some members might not be found anymore (bc they were removed), so they'll be marked with IsSkip=true
-	* - Generate a DynamicSchemaFormatter using this schema
-	* - Use it to read the data
-	*/
+	 * A schema just contains the
+	 * - The Type the Schema is for
+	 * - All serialized members (ordered!)
+	 * - For each member it contains:
+	 *		- The persistent name (normally that's just the member-name, but can overriden by the user)
+	 *		- Whether or not to skip the entry (when reading an old object some members might not be present anymore)
+	 *		
+	 * The persistent name is only used when writing the Schema; and while reading the persistent name is just recorded but never used,
+	 * because it only serves to lookup the target member.
+	 * 
+	 * The "primary" means that the schema is the current one; as in it was not read from some data.
+	 * In other words, its the schema for the type as it currently is in the application, not a schema of an older version of the type.
+	 *
+	 * 
+	 * At serialization time:
+	 * - Write schema to buffer
+	 * - Write objects using schema formatter (which will prefix every written member with its size)
+	 *
+	 * At deserialization time:
+	 * - Read schema from file
+	 *    - Some members might not be found anymore (bc they were removed), so they'll be marked with IsSkip=true
+	 * - Generate a DynamicSchemaFormatter using this schema
+	 * - Use it to read the data
+	 */
+
+	// !! DON'T USE GetHashCode(), the current implementation does not consider writing the hash to a file (and .NET hashcodes always change from one program start to another)
+	// !! If we ever want to embedd the hashcode we need to switch to xxHash or something (xxHash seems to be the best)
 	class Schema
 	{
-		public Type Type;
-		public List<SchemaMember> Members = new List<SchemaMember>();
+		public Type Type { get; }
+		public bool IsPrimary { get; }
+		public List<SchemaMember> Members { get; } = new List<SchemaMember>();
+
+		public IFormatter SpecificFormatter;
+		public IFormatter ReferenceFormatter;
+
+		public Schema(bool isPrimary, Type type)
+		{
+			IsPrimary = isPrimary;
+			Type = type;
+		}
 
 		// this assumes that a schema will not change after being created
 		// that's ok since Schema is not public
@@ -40,7 +64,16 @@
 
 			for (int i = 0; i < Members.Count; i++)
 			{
-				if (Members[i].Member.MemberInfo != other.Members[i].Member.MemberInfo)
+				var a = Members[i];
+				var b = other.Members[i];
+
+				if (a.PersistentName != b.PersistentName)
+					return false;
+
+				if (a.IsSkip != b.IsSkip)
+					return false;
+
+				if (a.Member.MemberInfo != b.Member.MemberInfo)
 					return false;
 			}
 
@@ -65,6 +98,7 @@
 				{
 					var hashSource = Type.FullName + string.Join("", Members.Select(m => m.Member.MemberType.FullName + m.Member.MemberInfo.Name));
 					_hash = hashSource.GetHashCode();
+
 				}
 
 			return _hash;
@@ -73,7 +107,7 @@
 
 
 
-		internal static MemberInfo FindMember(Type type, string name)
+		internal static MemberInfo FindMemberInType(Type type, string name)
 		{
 			foreach (var member in type.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
 			{
@@ -110,15 +144,413 @@
 			return false;
 		}
 
+
+		// Removed until we are ready to deal with the V2 of version tolerance (to include type-information)
+		/*
+		static IFormatter DetermineOverrideFormatter(MemberInfo memberInfo)
+		{
+			var prevType = memberInfo.GetCustomAttribute<PreviousType>();
+			if (prevType != null)
+				return GetGenericFormatter(prevType.MemberType);
+
+			var prevFormatter = memberInfo.GetCustomAttribute<PreviousFormatter>();
+			if (prevFormatter != null)
+			{
+				var formatter = ReflectionHelper.FindClosedType(prevFormatter.FormatterType, typeof(IFormatter<>));
+				if (formatter == null)
+					throw new Exception($"Type '{prevFormatter.FormatterType.FullName}' must inherit from IFormatter<>");
+
+				return (IFormatter)Activator.CreateInstance(formatter);
+			}
+
+			return null;
+		}
+		*/
 	}
 
-	class SchemaMember
+	/*
+		 * todo:
+		 * 
+		 * Idea:
+		 * Eventually we want to be able to skip over Schemata.
+		 * To do this we'd prefix the data with: 
+		 *	- Number of Schemata
+		 *	- All the type names + hash of their schema
+		 *	- offset to skip over the schema data
+		 * 
+		 * Problem:
+		 *  - schema definitions contain type names, which have been written by the TypeFormatter.
+		 *    We MUST read those because it's possible that a Type is later referenced again (that time by its ID!)
+		 *    So we must read all the type-names anyway so the type-name-cache is populated correctly.
+		 *    
+		 *  - Right now we already write the Schema before the type, and we tell the serializer that we've made use of that schema.
+		 *    That way the serializer knows which schemata to prefix the data with.
+		 *    The problem is of course that we're using a HashSet for that, which means the order is back to random.
+		 *    So the type-names are actually not written in the right order.
+		 *
+		 *  - if we write schema types after the data; then the data contains the actual strings,
+		 *    and while reading we need to read the schemata FIRST, potentially referring us to a string that was supposedly already there but is not
+		 *
+		 *  -> can we know the schema beforehand? no, there might be objects that are hidden in <object> or interface fields!
+		 *
+		 *  -> we must write type names at the very beginning
+		 *
+		 *
+		 * Other approach:
+		 * Schema data interweaved. Keep track of what types are written.
+		 * When a type name is written in full, also write the schema for it right into the data (with has prefix)
+		 * When reading we read the type (and cache it), then the schema hash; potentially ignoring the schema data because we already have a schema+formatter for that
+		 *
+		 * 1.) Write schema together with type-name as needed
+		 * 2.) While reading, make use of the schema hash to reuse an existing schema + use "skip-reader" to quickly read over the schema data (only happens once, so its ok)
+		 *
+		 * Trying to rescue approach #1?
+		 * We would need to ensure type names are written in full only in the schema, because that is read first;
+		 * - When a type has to be written: add it to a list, pseudo caching it, and instantly emit the cacheId.
+		 * - After writing the data: emit schemata in the correct order; emit the type names in full.
+		 *
+		 *
+		 * Approach 1 vs 2:
+		 * - First approach collects all schema data into the beginning of the file
+		 *   + could potentially extract it into a separate thing maybe?
+		 * - Second approach writes schema data inline with the type-name
+		 *   + easier to do
+		 *
+		 * Is one always faster than the other?
+		 *  + inline is likely faster to implement
+		 *
+		 *
+		 * Scenario: Multiple files all with same schema
+		 * - would like to have schema data shared somewhere
+		 * - but then we'd like to put all the objects into one big file anyway
+		 * - doing that would require some sort of database because we need fast access to entries and being able to rewrite an entry (with dynamic size change)
+		 *
+		 * Abort?
+		 * - for simple versioning maybe use json
+		 * - but we'd lose IExternalRootObject, which is super-bad, but we could do some special formatting, to write an ID instead just like Ceras
+		 * - why do we even want versioning info??
+		 *    -> settings files? maybe DB-like functionality?
+		 * - assuming db: where do we put lists and strings?
+		 *
+		 */
+
+
+	/*
+	 * The SchemaDb maintains a list of all the Schmata for each Type.
+	 * Initially there's only one Schema per Type, but if we
+	 * read with VersionTolerance more Schemata might be added.
+	 * 
+	 * SchemaDb was previously static, but that's not possible because different serializers most likely have different configurations.
+	 * Which means that even the primary schema of a type may be different (because of different TargetMembers, ShouldSerializeObject, ...)
+	 */
+	struct SchemaDb
 	{
-		public string PersistentName; // If set, this gets written as type name
-		public bool IsSkip; // If this is true, member and override formatter are not used; while reading the element is skipped (by reading its size)
-		public SerializedMember Member;
-		
+		readonly SerializerConfig _config;
+		readonly Dictionary<Type, Schema> _typeToPrimary;
+		readonly Dictionary<Type, List<Schema>> _typeToSecondaries;
+
+		public SchemaDb(SerializerConfig config)
+		{
+			_config = config;
+			_typeToPrimary = new Dictionary<Type, Schema>();
+			_typeToSecondaries = new Dictionary<Type, List<Schema>>();
+		}
+
+
+		// Creates the primary schema for a given type
+		internal Schema GetOrCreatePrimarySchema(Type type)
+		{
+			if (_typeToPrimary.TryGetValue(type, out Schema s))
+				return s;
+
+
+			Schema schema = new Schema(true, type);
+
+			var flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+			var classConfig = type.GetCustomAttribute<MemberConfig>();
+
+			foreach (var m in type.GetFields(flags).Cast<MemberInfo>().Concat(type.GetProperties(flags)))
+			{
+				bool isPublic;
+				bool isField = false, isProp = false;
+				bool isReadonly = false;
+				bool isCompilerGenerated = false;
+
+				if (m is FieldInfo f)
+				{
+					// Skip readonly
+					if (f.IsInitOnly)
+					{
+						isReadonly = true;
+
+						if (_config.ReadonlyFieldHandling == ReadonlyFieldHandling.Off)
+							continue;
+					}
+
+					// Readonly auto-prop backing fields
+					if (f.GetCustomAttribute<CompilerGeneratedAttribute>() != null)
+						isCompilerGenerated = true;
+
+					// By default we skip hidden/compiler generated fields, so we don't accidentally serialize properties twice (property, and then its automatic backing field as well)
+					if (isCompilerGenerated)
+						if (_config.SkipCompilerGeneratedFields)
+							continue;
+
+					isPublic = f.IsPublic;
+					isField = true;
+				}
+				else if (m is PropertyInfo p)
+				{
+					// There's no way we can serialize a prop that we can't read and write, even {private set;} props would be writeable,
+					// That is becasue there is actually physically no set() method we could possibly call. Just like a "computed property".
+					// As for readonly props (like string Name { get; } = "abc";), the only way to serialize them is serializing the backing fields, which is handled above (skipCompilerGenerated)
+					if (!p.CanRead || !p.CanWrite)
+						continue;
+
+					// This checks for indexers, an indexer is classified as a property
+					if (p.GetIndexParameters().Length != 0)
+						continue;
+
+					isPublic = p.GetMethod.IsPublic;
+					isProp = true;
+				}
+				else
+					continue;
+
+				var serializedMember = SerializedMember.Create(m);
+
+				// should we allow users to provide a formatter for each old-name (in case newer versions have changed the type of the element?)
+				var attrib = m.GetCustomAttribute<PreviousNameAttribute>();
+
+				if (attrib != null)
+				{
+					VerifyName(attrib.Name);
+					foreach (var n in attrib.AlternativeNames)
+						VerifyName(n);
+				}
+
+
+				var schemaMember = new SchemaMember(attrib?.Name ?? m.Name, serializedMember);
+
+
+				//
+				// 1.) ShouldSerializeMember - use filter if there is one
+				if (_config.ShouldSerializeMember != null)
+				{
+					var filterResult = _config.ShouldSerializeMember(serializedMember);
+
+					if (filterResult == SerializationOverride.ForceInclude)
+					{
+						schema.Members.Add(schemaMember);
+						continue;
+					}
+					else if (filterResult == SerializationOverride.ForceSkip)
+					{
+						continue;
+					}
+				}
+
+				//
+				// 2.) Use member-attribute
+				var ignore = m.GetCustomAttribute<Ignore>(true) != null;
+				var include = m.GetCustomAttribute<Include>(true) != null;
+
+				if (ignore && include)
+					throw new Exception($"Member '{m.Name}' on type '{type.Name}' has both [Ignore] and [Include]!");
+
+				if (ignore)
+				{
+					continue;
+				}
+
+				if (include)
+				{
+					schema.Members.Add(schemaMember);
+					continue;
+				}
+
+
+				//
+				// After checking the user callback (ShouldSerializeMember) and the direct attributes (because it's possible to directly target a backing field like this: [field: Include])
+				// we now need to check for compiler generated fields again.
+				// The intent is that if 'skipCompilerGenerated==false' then we allow checking the callback, as well as the attributes.
+				// But (at least for now) we don't want those problematic fields to be included by default,
+				// which would happen if any of the class or global defaults tell us to include 'private fields', because it is too dangerous to do it globally.
+				// There are all sorts of spooky things that we never want to include like:
+				// - enumerator-state-machines
+				// - async-method-state-machines
+				// - events (maybe?)
+				// - cached method invokers for 'dynamic' objects
+				// Right now I'm not 100% certain all or any of those would be a problem, but I'd rather test it first before just blindly serializing this unintended stuff.
+				if (isCompilerGenerated)
+					continue;
+
+				//
+				// 3.) Use class-attribute
+				if (classConfig != null)
+				{
+					if (IsMatch(isField, isProp, isPublic, classConfig.TargetMembers))
+					{
+						schema.Members.Add(schemaMember);
+						continue;
+					}
+				}
+
+				//
+				// 4.) Use global defaults
+				if (IsMatch(isField, isProp, isPublic, _config.DefaultTargets))
+				{
+					schema.Members.Add(schemaMember);
+					continue;
+				}
+			}
+
+
+			// Need to sort by name to ensure fields are always in the same order (yes, that is actually a real problem that really happens, even on the same .NET version, same computer, ...) 
+			schema.Members.Sort(SchemaMemberComparer.Instance);
+
+
+			_typeToPrimary.Add(type, schema);
+
+			return schema;
+		}
+
+		// Reads a schema from given data
+		internal Schema ReadSchema(byte[] buffer, ref int offset, Type type)
+		{
+			// todo 1:
+			// Maybe we'll add some sort of skipping mechanism later.
+			// We write count, type-names, hashes, offset to data
+			// And when reading we can prepare all the schema serializers,
+			// and if we have all of them already we can skip straight to the data
+			// which would save us quite a bit of time.
+
+
+			//
+			// Get list of secondary schemata
+			List<Schema> secondaries;
+			if(!_typeToSecondaries.TryGetValue(type, out secondaries))
+			{
+				secondaries = new List<Schema>();
+				_typeToSecondaries.Add(type, secondaries);
+			}
+
+
+			//
+			// Read Schema
+			var schema = new Schema(false, type);
+
+			var memberCount = SerializerBinary.ReadInt32(buffer, ref offset);
+			for (int i = 0; i < memberCount; i++)
+			{
+				var name = SerializerBinary.ReadString(buffer, ref offset);
+
+				var member = Schema.FindMemberInType(type, name);
+
+				if(member == null)
+					schema.Members.Add(new SchemaMember(name));
+				else
+					schema.Members.Add(new SchemaMember(name, SerializedMember.Create(member, true)));
+			}
+
+			//
+			// Add entry or return existing
+			var existing = secondaries.IndexOf(schema);
+			if(existing == -1)
+			{
+				secondaries.Add(schema);
+				return schema;
+			}
+			else
+			{
+				return secondaries[existing];
+			}
+		}
+
+		internal void WriteSchema(ref byte[] buffer, ref int offset, Schema schema)
+		{
+			if (!schema.IsPrimary)
+				throw new InvalidOperationException("Can't write schema that doesn't match the primary. This is a bug, please report it on GitHub!");
+
+			// Write the schema...
+			var members = schema.Members;
+			SerializerBinary.WriteInt32(ref buffer, ref offset, members.Count);
+
+			for (int i = 0; i < members.Count; i++)
+				SerializerBinary.WriteString(ref buffer, ref offset, members[i].PersistentName);
+		}
+
+
+
+		static void VerifyName(string name)
+		{
+			if (string.IsNullOrWhiteSpace(name))
+				throw new Exception("Member name can not be null/empty");
+			if (char.IsNumber(name[0]) || char.IsControl(name[0]))
+				throw new Exception("Name must start with a letter");
+
+			const string allowedChars = "_";
+
+			for (int i = 1; i < name.Length; i++)
+				if (!char.IsLetterOrDigit(name[i]) && !allowedChars.Contains(name[i]))
+					throw new Exception($"The name '{name}' has character '{name[i]}' at index '{i}', which is not allowed. Must be a letter or digit.");
+		}
+
+		static bool IsMatch(bool isField, bool isProp, bool isPublic, TargetMember targetMembers)
+		{
+			if (isField)
+			{
+				if (isPublic)
+				{
+					if ((targetMembers & TargetMember.PublicFields) != 0)
+						return true;
+				}
+				else
+				{
+					if ((targetMembers & TargetMember.PrivateFields) != 0)
+						return true;
+				}
+			}
+
+			if (isProp)
+			{
+				if (isPublic)
+				{
+					if ((targetMembers & TargetMember.PublicProperties) != 0)
+						return true;
+				}
+				else
+				{
+					if ((targetMembers & TargetMember.PrivateProperties) != 0)
+						return true;
+				}
+			}
+
+			return false;
+		}
+	}
+
+	struct SchemaMember
+	{
+		public readonly string PersistentName; // If set, this gets written as type name
+		public readonly SerializedMember Member;
+
+		public bool IsSkip => Member.MemberInfo == null; // If this is true, then member and override formatter are not used; while reading the element is skipped (by reading its size)
+
 		// public IFormatter OverrideFormatter;
+
+		public SchemaMember(string persistentName, SerializedMember serializedMember)
+		{
+			PersistentName = persistentName;
+			Member = serializedMember;
+		}
+
+		public SchemaMember(string persistentName)
+		{
+			PersistentName = persistentName;
+			Member = default;
+		}
 
 		public override string ToString()
 		{

--- a/src/Ceras/Versioning/Schema.cs
+++ b/src/Ceras/Versioning/Schema.cs
@@ -117,7 +117,8 @@
 		public string PersistentName; // If set, this gets written as type name
 		public bool IsSkip; // If this is true, member and override formatter are not used; while reading the element is skipped (by reading its size)
 		public SerializedMember Member;
-		public IFormatter OverrideFormatter;
+		
+		// public IFormatter OverrideFormatter;
 
 		public override string ToString()
 		{

--- a/src/Ceras/Versioning/SchemaFormatter.cs
+++ b/src/Ceras/Versioning/SchemaFormatter.cs
@@ -24,10 +24,10 @@ namespace Ceras.Helpers
 		DeserializeDelegate<T> _deserializer;
 
 
-		const int FieldSizePrefixBytes = 2;
-		static readonly Type SizeType = typeof(short);
-		static readonly MethodInfo SizeWriteMethod = typeof(SerializerBinary).GetMethod(nameof(SerializerBinary.WriteInt16Fixed));
-		static readonly MethodInfo SizeReadMethod = typeof(SerializerBinary).GetMethod(nameof(SerializerBinary.ReadInt16Fixed));
+		const int FieldSizePrefixBytes = 4;
+		static readonly Type SizeType = typeof(uint);
+		static readonly MethodInfo SizeWriteMethod = typeof(SerializerBinary).GetMethod(nameof(SerializerBinary.WriteUInt32Fixed));
+		static readonly MethodInfo SizeReadMethod = typeof(SerializerBinary).GetMethod(nameof(SerializerBinary.ReadUInt32Fixed));
 
 
 		public SchemaDynamicFormatter(CerasSerializer ceras, Schema schema)

--- a/src/Ceras/Versioning/SchemaMemberComparer.cs
+++ b/src/Ceras/Versioning/SchemaMemberComparer.cs
@@ -4,18 +4,56 @@
 	using System.Collections.Generic;
 	using Helpers;
 
+	/*
+	 * Sorting by memberType first gives us improved performance
+	 * - We're immune to the crazy reordering of members that all C# compilers sometimes do for no (obvious) reason.
+	 * - Better cache coherency when using the formatters, since we'll keep using the same type of formatter over and over again, instead of switching around wildly.
+	 * - Because fixed-size types get grouped together, this enables a huge optimization: We can do one big(combined) size-check for all of them; which enables us to use the "NoSizeCheck" versions of the methods in SerializerBinary (they don't exist yet, will be added together with them, todo)
+	 * - Sorting by declaring type last will improve our robustness in rare edge cases. Since we're doing ordering anyway, this optimization comes for free! (the edge case being when class A:B, and B:C, and later A and B swap names and there are private fields in each that have the same name)
+	 */
 	class SchemaMemberComparer : IComparer<SchemaMember>
 	{
 		public static readonly SchemaMemberComparer Instance = new SchemaMemberComparer();
 
-		static string Prefix(SchemaMember m) => m.Member.IsField ? "f" : "p";
+		static string Suffix(SchemaMember m) => m.Member.IsField ? "f" : "p";
 
 		public int Compare(SchemaMember x, SchemaMember y)
 		{
-			var name1 = Prefix(x) + x.Member.MemberType.FullName + x.PersistentName;
-			var name2 = Prefix(y) + y.Member.MemberType.FullName + y.PersistentName;
+			var name1 = GetComparisonName(x);
+			var name2 = GetComparisonName(y);
 
 			return string.Compare(name1, name2, StringComparison.Ordinal);
+		}
+
+		static string GetComparisonName(SchemaMember m)
+		{
+			// It's not just the contents, it's also this exact ordering of the elements that is important as well. Read above for more information
+			return
+				(IsFixedSize(m.Member.MemberType) ? "" : "") + // Enforce fixed-size types to group together
+				m.Member.MemberType.FullName + // Optimize for formatter reuse
+				m.PersistentName + // Actual name
+				m.Member.MemberInfo.DeclaringType.FullName + // Ensure things are ordered correctly even when there are (inherited) fields of the exact same name and type
+				(m.Member.IsField ? "f" : "p"); // Unsure if it can happen in some scenarios, but we need to differentiate between fields and props
+		}
+
+		static bool IsFixedSize(Type t)
+		{
+			if(t.IsPrimitive)
+				return true;
+
+			if(!t.IsValueType)
+				return false;
+
+			// It is a struct
+			// Structs can be fixed size if all of its members are fixed size
+			foreach(var f in t.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance))
+			{
+				if(!IsFixedSize(f.FieldType))
+					return false;
+			}
+
+			// The struct contains only fixed-size types, great!
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
### What're we doing here
In preparation for the "readonly field handling" feature as outlined in #9 (sorta at the end of the thread) I had to refactor a lot of stuff; primarily the way Schemata are handled.

So as a side-effect the VersionTolerance feature got cleaned up a lot. Also there have been huge performance improvements to it (preventing duplicate Schema entries, caching generated dynamic formatters, ...)

Once this feature is done Ceras will be able to handle readonly fields in various ways.
The current idea is that it should work like this (copied from tutorial step10)

			 * Situation:
			 * 
			 * You have an object, which has a 'readonly Settings CurrentSettings;'.
			 * Of course that can't (normally) be serialized or deserialized.
			 * But Ceras can still deal with it.
			 * 
			 * Default: readonly fields are completely ignored
			 * 
			 * Members: save/restore the content of the variable itself
			 * 
			 * Forced: like members, but force a fix if there's a mismatch. Uses reflection, so should be used sparingly. 

A mismatch is when the target field is null but the data says it shouldn't be (or vice versa), or when the object in the field has a different type than what the data says it shoudl be.

### Properties:
get-only properties cannot be changed through reflection as they literally have no way set-method. Like  a computed property (example: `public int A => Environment.TickCount;`). 
As for get-only-auto-properties: Setting them would require setting the compiler-generated backing field. 
While it's very easy to demonstrate that it it's possible, in practice (like once you start to really investigate it) you'll find that it is 100% madness to even attempt it.
See the issue about delegate serialization #11 to get an idea what awaits anyone who thinks about messing with compiler-generated fields.

