### PR TITLE
don't generate duplicate formatter fields

### DIFF
--- a/src/Ceras.AotGenerator/SourceGenerator/SourceFormatterGenerator.cs
+++ b/src/Ceras.AotGenerator/SourceGenerator/SourceFormatterGenerator.cs
@@ -34,7 +34,7 @@
 
 		static void GenerateFormatterFields(StringBuilder text, Schema schema)
 		{
-			foreach (var m in schema.Members)
+			foreach (var m in schema.Members.DistinctBy(m => m.MemberType))
 			{
 				var t = m.MemberType;
 				var fieldName = MakeFormatterFieldName(t);


### PR DESCRIPTION
Ensures that only one formatter per distinct field type is created for generated formatters

resolves #49 