### PR TITLE
Add a setting to specify the object cache comparer

### DIFF
--- a/src/Ceras/CerasSerializer.cs
+++ b/src/Ceras/CerasSerializer.cs
@@ -352,7 +352,7 @@ namespace Ceras
 			{
 				var d = new InstanceData();
 				d.CurrentRoot = null;
-				d.ObjectCache = new ObjectCache();
+				d.ObjectCache = new ObjectCache(Config.Advanced.ObjectCacheComparer);
 				d.TypeCache = new TypeCache(_knownTypes);
 				d.EncounteredSchemaTypes = new HashSet<Type>();
 

--- a/src/Ceras/Config/SerializerConfig.cs
+++ b/src/Ceras/Config/SerializerConfig.cs
@@ -246,6 +246,7 @@
 		bool IAdvancedConfig.RespectNonSerializedAttribute { get; set; } = true;
 		BitmapMode IAdvancedConfig.BitmapMode { get; set; } = BitmapMode.DontSerializeBitmaps;
 		AotMode IAdvancedConfig.AotMode { get; set; } = AotMode.None;
+		IEqualityComparer<object> IAdvancedConfig.ObjectCacheComparer { get; set; }
 
 		#endregion
 		
@@ -379,6 +380,12 @@
 		/// On an AoT platforms (for example Unity IL2CPP) Ceras can not use dynamic code generation. When enabled, Ceras will use reflection for everything where it would otherwise use dynamic code generation. This is slow, but it allows for testing and debugging on those platforms until 
 		/// </summary>
 		AotMode AotMode { get; set; }
+
+		/// <summary>
+		/// The <see cref="IEqualityComparer{T}"/> to use for the object cache. If this is <see langword="null"/>, the default <see cref="EqualityComparer{T}"/> for <see cref="object"/> will be used.
+		/// <para>Default: <see langword="null"/></para>
+		/// </summary>
+		IEqualityComparer<object> ObjectCacheComparer { get; set; }
 	}
 
 	public interface ISizeLimitsConfig

--- a/src/Ceras/Helpers/ObjectCache.cs
+++ b/src/Ceras/Helpers/ObjectCache.cs
@@ -8,12 +8,21 @@
     class ObjectCache
 	{
 		// While serializing we add all encountered objects and give them an ID (their index), so when we encounter them again we can just write the index instead.
-		readonly Dictionary<object, int> _serializationCache = new Dictionary<object, int>(64);
+		readonly Dictionary<object, int> _serializationCache;
 
 		// At deserialization-time we keep adding all new objects to this list, so when we find a back-reference we can take it from here.
 		// RefProxy enables us to deserialize even the most complex scenarios (For example: Objects that directly reference themselves, while they're not even fully constructed yet)
 		readonly List<RefProxy> _deserializationCache = new List<RefProxy>(64);
 
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ObjectCache"/> class.
+		/// </summary>
+		/// <param name="comparer">The <see cref="IEqualityComparer{T}"/> to use.</param>
+		public ObjectCache(IEqualityComparer<object> comparer = null)
+		{
+			_serializationCache = new Dictionary<object, int>(64, comparer);
+		}
 
 		// Serialization:
 		// If this object was encountered before, retrieve its ID


### PR DESCRIPTION
This allows an IEqualityComparer to be specified for the object cache through the Advanced.ObjectCacheComparer property in SerializerConfig.

By default, the default EqualityComparer for Object will be used.

For example, a user may wish to set this property to an IEqualityComparer that compares objects for reference equality to allow reference preservation for mutable classes that override Equals() and GetHashCode().