### PR TITLE
Provide missing namespace to AOT generator

### DIFF
--- a/src/Ceras.AotGeneratorApp/Program.cs
+++ b/src/Ceras.AotGeneratorApp/Program.cs
@@ -27,7 +27,7 @@ namespace CerasAotFormatterGenerator
 
 			var asms = inputAssemblies.Select(Assembly.LoadFrom);
 			StringBuilder fullCode = new StringBuilder(25 * 1000);
-			Generator.Generate(asms, fullCode);
+			Generator.Generate("AotSerialization", asms, fullCode);
 
 			Console.WriteLine($"Saving...");
 

--- a/src/Ceras.UnityAddon/Editor/EditorExtension.cs
+++ b/src/Ceras.UnityAddon/Editor/EditorExtension.cs
@@ -27,7 +27,7 @@ namespace Ceras.Editor
 
 			// Generate source-code for all formatters
 			var sb = new StringBuilder(25 * 1000);
-			Generator.Generate(assemblies, sb);
+			Generator.Generate("AotSerialization", assemblies, sb);
 			var output = sb.ToString();
 
 			// Check if the output is already exactly the same


### PR DESCRIPTION
This fixes #92 

If you think of a better name than "AotSerialization" for the namespace, please let me know and I'll edit this commit.

Thanks,
Daniel