### PR TITLE
Various fixes for AOT compilation

### DIFF
--- a/src/Ceras.AotGenerator/Generator.cs
+++ b/src/Ceras.AotGenerator/Generator.cs
@@ -72,8 +72,17 @@ namespace CerasAotFormatterGenerator
 				// Get first, remove from "to explore" list, and add it to the "done" list.
 				var t = newTypes.First();
 
-				if(t.IsArray)
+				if (t.IsArray)
+				{
+					newTypes.Remove(t);
+					processedTypes.Add(t);
 					t = t.GetElementType();
+
+					if (processedTypes.Contains(t))
+					{
+						continue;
+					}
+				}
 
 				newTypes.Remove(t);
 				processedTypes.Add(t);

--- a/src/Ceras.AotGenerator/Generator.cs
+++ b/src/Ceras.AotGenerator/Generator.cs
@@ -91,6 +91,11 @@ namespace CerasAotFormatterGenerator
 					// Skip int, string, Type, ...
 					continue;
 
+				if (t.IsAbstract && asms.Any(x => x.GetTypes().Contains(t)))
+				{
+					newTypes.AddRange(asms.SelectMany(x => x.GetTypes()).Where(y => !y.IsAbstract && y.IsSubclassOf(t) && !processedTypes.Contains(y)));
+				}
+
 				if (t.IsAbstract || t.ContainsGenericParameters)
 					// Can't explore abstract or open generics
 					continue;

--- a/src/Ceras.AotGenerator/Generator.cs
+++ b/src/Ceras.AotGenerator/Generator.cs
@@ -57,6 +57,7 @@ namespace CerasAotFormatterGenerator
 				config = (SerializerConfig)configMethods[0].Invoke(null, null);
 
 			var ceras = new CerasSerializer(config);
+			ceras.IsDuringAOTGeneration = true;
 
 
 			// Start with KnownTypes and user-marked types...

--- a/src/Ceras.AotGenerator/Generator.cs
+++ b/src/Ceras.AotGenerator/Generator.cs
@@ -1,3 +1,5 @@
+//#define ENHANCED_ASSEMBLY_DEBUG_INFO // Having this enabled kills Unity play-in-editor startup performance
+
 using System;
 
 namespace CerasAotFormatterGenerator
@@ -158,7 +160,9 @@ namespace CerasAotFormatterGenerator
 		{
 			if (_resolverRegistered)
 				return;
+#if ENHANCED_ASSEMBLY_DEBUG_INFO
 			AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
+#endif
 			_resolverRegistered = true;
 		}
 

--- a/src/Ceras.AotGenerator/Helpers/TypeNameHelper.cs
+++ b/src/Ceras.AotGenerator/Helpers/TypeNameHelper.cs
@@ -57,6 +57,12 @@ namespace System
 					+ "_" 
 					+ string.Join("_", type.GetGenericArguments().Select(t => t.ToFriendlyName(false)).ToArray());
 			}
+			else if (type.IsArray)
+			{
+				int rank = type.GetArrayRank();
+				string baseName = name.Split('[')[0];
+				return $"{baseName}_Array{rank}";
+			}
 			else
 			{
 				return name;

--- a/src/Ceras.AotGenerator/SourceGenerator/SourceFormatterGenerator.cs
+++ b/src/Ceras.AotGenerator/SourceGenerator/SourceFormatterGenerator.cs
@@ -13,12 +13,13 @@ namespace CerasAotFormatterGenerator
 		public static void GenerateAll(string ns, List<Type> targets, Dictionary<Type, Type> aotHint,
             CerasSerializer ceras, StringBuilder text)
         {
-            text.AppendLine(@"
-// ReSharper disable All
-
-#nullable disable
-#pragma warning disable 649
-");
+	        text.AppendLine("// ReSharper disable All");
+	        text.AppendLine("");
+#if !CSHARP_7_OR_LATER || UNITY_2020_2_OR_NEWER
+	        text.AppendLine("#nullable disable");
+#endif
+	        text.AppendLine("#pragma warning disable 649");
+	        text.AppendLine("");
 			text.AppendLine("using Ceras;");
 			text.AppendLine("using Ceras.Formatters;");
 			text.AppendLine("using Ceras.Formatters.AotGenerator;");
@@ -48,7 +49,9 @@ $@"	public static class GeneratedFormatters
 
 			text.Length -= Environment.NewLine.Length;
 			text.AppendLine("}");
-            text.AppendLine("#nullable restore");
+#if !CSHARP_7_OR_LATER || UNITY_2020_2_OR_NEWER
+			text.AppendLine("#nullable restore");
+#endif
             text.AppendLine("#pragma warning restore 649");
             text.AppendLine();
         }

--- a/src/Ceras.AotGenerator/SourceGenerator/SourceFormatterGenerator.cs
+++ b/src/Ceras.AotGenerator/SourceGenerator/SourceFormatterGenerator.cs
@@ -27,7 +27,7 @@ namespace CerasAotFormatterGenerator
 			text.AppendLine($"namespace {ns}");
 			text.AppendLine("{");
 
-            var setFormattersHint = aotHint.Keys.Select((t, i) => $"\t\t\t{aotHint[t].ToFriendlyName(true)} var{i} = default;\n\t\t\tconfig.ConfigType<{t.ToFriendlyName(true)}>().CustomFormatter = var{i};");
+            var setFormattersHint = aotHint.Keys.Select((t, i) => $"\t\t\t{aotHint[t].ToFriendlyName(true)} var{i} = default;{Environment.NewLine}\t\t\tconfig.ConfigType<{t.ToFriendlyName(true)}>().CustomFormatter = var{i};");
             var setCustomFormatters = targets.Select(t => $"\t\t\tconfig.ConfigType<{t.ToFriendlyName(true)}>().CustomFormatter = new {t.ToVariableSafeName()}Formatter();");
 			text.AppendLine(
 $@"	public static class GeneratedFormatters

--- a/src/Ceras/CerasSerializer.cs
+++ b/src/Ceras/CerasSerializer.cs
@@ -183,6 +183,8 @@ namespace Ceras
 		int _recursionDepth = 0;
 		RecursionMode _mode = RecursionMode.Idle; // while in one mode we cannot enter the others
 
+		internal bool IsDuringAOTGeneration { get; set; } = false;
+
 		/// <summary>
 		/// A "free" property where you can store anything.
 		/// <para>This is useful for scenarios where callbacks like <see cref="OnBeforeSerializeAttribute"/> are used, because the <see cref="CerasSerializer"/> instance is passed to those methods (assuming they take a <see cref="CerasSerializer"/> instance as an argument). That way you can obtain the <see cref="UserContext"/> inside those methods.</para>

--- a/src/Ceras/Formatters/CollectionFormatter.cs
+++ b/src/Ceras/Formatters/CollectionFormatter.cs
@@ -336,7 +336,16 @@
 
 
 			if (value == null)
-				value = _capacityConstructor((int)itemCount);
+			{
+				if (_capacityConstructor != null)
+				{
+					value = _capacityConstructor((int)itemCount);
+				}
+				else
+				{
+					value = Activator.CreateInstance<TCollection>();
+				}
+			}
 			else
 			{
 				if (value.Count > 0)

--- a/src/Ceras/Formatters/ReferenceFormatter.cs
+++ b/src/Ceras/Formatters/ReferenceFormatter.cs
@@ -536,9 +536,9 @@
 			}
 
 			// Can't call directly, need to invoke through reflection so T gets casted up/down correctly.
-			var args = new object[3];
 			return (ref byte[] buffer, ref int offset, T value) =>
 			{
+				var args = new object[3];
 				args[0] = buffer;
 				args[1] = offset;
 				args[2] = value;
@@ -559,10 +559,9 @@
 				// return (ref byte[] buffer, ref int offset, T value) => { f.Serialize(ref buffer, ref offset, value); };
 			}
 
-
-			var args = new object[3];
 			return new DeserializeDelegate<T>((byte[] buffer, ref int offset, ref T value) =>
 			{
+				var args = new object[3];
 				args[0] = buffer;
 				args[1] = offset;
 				args[2] = value;

--- a/src/Ceras/Helpers/ReflectionHelper.cs
+++ b/src/Ceras/Helpers/ReflectionHelper.cs
@@ -641,7 +641,8 @@
 			}
 			else
 			{
-				return fullName ? type.FullName : type.Name;
+				var name = fullName ? type.FullName : type.Name;
+				return name.Replace("+", ".");
 			}
 		}
 	}

--- a/src/Ceras/Resolvers/ReinterpretFormatterResolver.cs
+++ b/src/Ceras/Resolvers/ReinterpretFormatterResolver.cs
@@ -29,6 +29,9 @@ namespace Ceras.Resolvers
 			if (!ReflectionHelper.IsBlittableType(type))
 				return null;
 
+			if (_ceras.IsDuringAOTGeneration && type.IsGenericType)
+				return null; // ReinterpretFormatter's unmanaged constraint on T causes the compiler reject generic types, but runtime doesn't enforce it
+
 			var formatterType = typeof(ReinterpretFormatter<>).MakeGenericType(type);
 
 			return (IFormatter) Activator.CreateInstance(formatterType);

--- a/src/Ceras/Resolvers/StandardFormatterResolver.cs
+++ b/src/Ceras/Resolvers/StandardFormatterResolver.cs
@@ -172,7 +172,7 @@
 		}
 
 
-		class KeyValuePairFormatter<TKey, TValue> : IFormatter<KeyValuePair<TKey, TValue>>
+		public class KeyValuePairFormatter<TKey, TValue> : IFormatter<KeyValuePair<TKey, TValue>>
 		{
 			IFormatter<TKey> _keyFormatter;
 			IFormatter<TValue> _valueFormatter;
@@ -196,7 +196,7 @@
 		}
 
 
-		class DateTimeFormatter : IFormatter<DateTime>
+		public class DateTimeFormatter : IFormatter<DateTime>
 		{
 			public void Serialize(ref byte[] buffer, ref int offset, DateTime value)
 			{
@@ -211,7 +211,7 @@
 			}
 		}
 
-		class DateTimeOffsetFormatter : IFormatter<DateTimeOffset>
+		public class DateTimeOffsetFormatter : IFormatter<DateTimeOffset>
 		{
 			public void Serialize(ref byte[] buffer, ref int offset, DateTimeOffset value)
 			{
@@ -228,7 +228,7 @@
 			}
 		}
 
-		class TimeSpanFormatter : IFormatter<TimeSpan>
+		public class TimeSpanFormatter : IFormatter<TimeSpan>
 		{
 			public void Serialize(ref byte[] buffer, ref int offset, TimeSpan value)
 			{
@@ -241,7 +241,7 @@
 			}
 		}
 
-		class BitVector32Formatter : IFormatter<BitVector32>
+		public class BitVector32Formatter : IFormatter<BitVector32>
 		{
 			public void Serialize(ref byte[] buffer, ref int offset, BitVector32 value)
 			{
@@ -255,7 +255,7 @@
 			}
 		}
 
-		class BigIntegerFormatter : IFormatter<BigInteger>
+		public class BigIntegerFormatter : IFormatter<BigInteger>
 		{
 			public void Serialize(ref byte[] buffer, ref int offset, BigInteger value)
 			{


### PR DESCRIPTION
I was evaluating Ceras for a project that's currently still on Unity 2019.4 in .NET standard 2.0 mode, and I figured I'd go ahead and share all the work I had to do to get AOT compilation to work properly for it.

Most of these things are just small bugs, but a few of them veer into new feature territory (like generating formatters for subclasses of an abstract base class).

I don't expect to do much more work here, and since this repo hasn't been updated in a few years I'm mostly just leaving it for anybody in the future who runs into these issues.